### PR TITLE
Adding SHA256 support

### DIFF
--- a/Oauth.php
+++ b/Oauth.php
@@ -106,6 +106,30 @@ abstract class OAuthSignatureMethod {
 }
 
 /**
+ * The HMAC-SHA256 signature method uses the HMAC-SHA256 signature algorithm 
+ */
+class OAuthSignatureMethod_HMAC_SHA256 extends OAuthSignatureMethod {
+  function get_name() {
+    return "HMAC-SHA256";
+  }
+
+  public function build_signature($request, $consumer, $token) {
+    $base_string = $request->get_signature_base_string();
+    $request->base_string = $base_string;
+
+    $key_parts = array(
+      $consumer->secret,
+      ($token) ? $token->secret : ""
+    );
+
+    $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
+    $key = implode('&', $key_parts);
+
+    return base64_encode(hash_hmac('sha256', $base_string, $key, true));
+  }
+}
+
+/**
  * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104] 
  * where the Signature Base String is the text and the key is the concatenated values (each first 
  * encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&' 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# phpoauth
+PHPOAUTH helps you quickly program OAuth capable applications in PHP. 
+
+You can create various supported Oauth signatures (Plaintext, SHA1, SHA256) with ease and do more. 
+We use this intensively for Netsuite integration with different 3rd party platforms. 
+
+Recently added SHA256 support as it is the commonly accepted standard now, since Plaintext, and SHA1 are now obsolete.
+
+# Example using SHA256
+```
+$url_to_request = "INSERT_URL";
+$app_token_consumer_key = "INSERT_CONSUMER_KEY";
+$app_token_consumer_secret = "INSERT_CONSUMER_SECRET";
+$user_token_id = "INSERT_USER_TOKEN";
+$user_token_secret = "INSERT_USER_TOKEN_SECRET";
+
+$nonce = mt_rand();
+$token = new OAuthToken($user_token_id, $user_token_secret);
+$consumer = new OAuthConsumer($app_token_consumer_key, $app_token_consumer_secret);
+        
+$sig = new OAuthSignatureMethod_HMAC_SHA256();
+
+$params = array(
+        'oauth_nonce' => $nonce,
+        'oauth_timestamp' => idate('U'),
+        'oauth_version' => '1.0',
+        'oauth_token' => $user_token_id,
+        'oauth_consumer_key' => $app_token_consumer_key,
+        'oauth_signature_method' => $sig->get_name()
+);
+
+$req = new OAuthRequest('GET', $url_to_request, $params);
+$req->set_parameter('oauth_signature', $req->build_signature($sig, $consumer, $token));
+```
+


### PR DESCRIPTION
Hi, Thank you for your work on this. We have used this class a lot for 3rd party integrations. Apparently some of the integrations are now requiring SHA256 signed authorization headers, which was not supported by the project. I have added SHA256 support as well and hope others can use it too. 
Cheers